### PR TITLE
Add TUI flag to start Bubble Tea program

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,18 @@ sudo gzip /usr/share/man/man1/cdactl.1
 
 ## Usage
 
+By default `cdactl` launches an interactive terminal UI:
+
+```sh
+cdactl
+```
+
+To skip the TUI and use CLI commands directly:
+
+```sh
+cdactl --tui=false network status
+```
+
 Run `cdactl` followed by a command and its respective options. Below are the available commands and their usage examples:
 
 ### Network Management

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,19 @@ module github.com/cdaprod/cdactl
 go 1.24.3
 
 require (
-	github.com/charmbracelet/bubbletea v1.3.6
-	github.com/charmbracelet/glamour v0.10.0
-	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
-	github.com/spf13/cobra v1.9.1
-	golang.org/x/term v0.31.0
+        github.com/cdaprod/cdactl/tui v0.0.0
+        github.com/charmbracelet/bubbletea v1.3.6
+        github.com/charmbracelet/glamour v0.10.0
+        github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+        github.com/spf13/cobra v1.9.1
+        golang.org/x/term v0.31.0
 )
 
 require (
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
-	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/aymerick/douceur v0.2.0 // indirect
-	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
+        github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+        github.com/aymerick/douceur v0.2.0 // indirect
+        github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
@@ -42,3 +43,5 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 )
+
+replace github.com/cdaprod/cdactl/tui => ./tui

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestTUIFlag verifies the --tui flag defaults to true and produces idempotent CLI output
+// when disabled.
+func TestTUIFlag(t *testing.T) {
+	flag := rootCmd.PersistentFlags().Lookup("tui")
+	if flag == nil {
+		t.Fatalf("tui flag not found")
+	}
+	if flag.Value.String() != "true" {
+		t.Fatalf("expected default true, got %s", flag.Value.String())
+	}
+
+	defer func() {
+		tuiEnabled = true
+		_ = flag.Value.Set("true")
+		rootCmd.SetArgs(nil)
+	}()
+
+	buf1 := new(bytes.Buffer)
+	rootCmd.SetOut(buf1)
+	rootCmd.SetErr(buf1)
+	rootCmd.SetArgs([]string{"--tui=false"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("first execute: %v", err)
+	}
+	out1 := buf1.String()
+	if !strings.Contains(out1, "--tui") {
+		t.Fatalf("expected help output, got %q", out1)
+	}
+
+	buf2 := new(bytes.Buffer)
+	rootCmd.SetOut(buf2)
+	rootCmd.SetErr(buf2)
+	rootCmd.SetArgs([]string{"--tui=false"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("second execute: %v", err)
+	}
+	out2 := buf2.String()
+
+	if out1 != out2 {
+		t.Errorf("expected idempotent output")
+	}
+}

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -2,7 +2,6 @@ package backup
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"time"


### PR DESCRIPTION
## Summary
- introduce `--tui` flag (enabled by default) to launch the Bubble Tea interface and fall back to CLI when disabled
- document how to run the TUI and CLI modes
- add regression test ensuring CLI fallback remains idempotent

## Testing
- `go test ./...`
- `(cd tui && go test ./...)`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68af3fcce754832684b8d153a15931fb