### PR TITLE
feat: add versioned tool installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@
 - **Dotfiles Management**: 
   - Initialize, add, pull, and sync dotfiles stored in the [cdaprod/cda.cfg](https://github.com/cdaprod/cda.cfg) repository.
   
-- **Credential Management**: 
+- **Credential Management**:
   - Securely store and retrieve credentials for various services using `export GPG_PASSPHRASE="your-own-secret-password"`.
+
+- **Tool Installation**:
+  - Install and update helper binaries from GitHub Releases with `cdactl install` and `cdactl update`.
 
 ## Diagram
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/Cdaprod/cdactl
+
+go 1.20
+
+require (
+	github.com/spf13/cobra v1.10.1
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
+github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/install.go
+++ b/install.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/Cdaprod/cdactl/internal/installer"
+	"github.com/spf13/cobra"
+)
+
+// cdactl install <tool>
+// Example:
+//
+//	cdactl install codex-switch
+var installCmd = &cobra.Command{
+	Use:   "install <tool>",
+	Short: "Install a tool from manifest",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tool := args[0]
+		cfg := installer.Config{
+			ToolsDir:    defaultToolsDir(),
+			PrefixBase:  "/opt/cdaprod",
+			BinDirLink:  "/usr/local/bin",
+			Channel:     channel,
+			Force:       force,
+			GHToken:     os.Getenv("GITHUB_TOKEN"),
+			HTTPTimeout: installer.DefaultHTTPTimeout,
+		}
+		return installer.Install(context.Background(), cfg, tool, version)
+	},
+}
+
+var (
+	version string
+	channel string
+	force   bool
+)
+
+func init() {
+	installCmd.Flags().StringVar(&version, "version", "", "specific release tag")
+	installCmd.Flags().StringVar(&channel, "channel", "stable", "release channel")
+	installCmd.Flags().BoolVar(&force, "force", false, "reinstall even if present")
+	rootCmd.AddCommand(installCmd)
+}

--- a/internal/installer/checksum.go
+++ b/internal/installer/checksum.go
@@ -1,0 +1,75 @@
+package installer
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := bufio.NewReader(f).WriteTo(h); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func verifySha256(filePath, checksumText string) error {
+	want := ""
+	for _, line := range strings.Split(checksumText, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) >= 1 {
+			if len(fields[0]) == 64 {
+				want = fields[0]
+				break
+			}
+			if len(fields[len(fields)-1]) == 64 {
+				want = fields[len(fields)-1]
+				break
+			}
+		}
+	}
+	if want == "" {
+		return fmt.Errorf("could not parse checksum file")
+	}
+	got, err := sha256File(filePath)
+	if err != nil {
+		return err
+	}
+	if strings.ToLower(want) != strings.ToLower(got) {
+		return fmt.Errorf("checksum mismatch: have %s want %s", got, want)
+	}
+	return nil
+}
+
+func guessInstalledBinary(verDir, binaryName string) (string, error) {
+	cand := filepath.Join(verDir, binaryName)
+	if fi, err := os.Stat(cand); err == nil && !fi.IsDir() {
+		return cand, nil
+	}
+	var found string
+	filepath.WalkDir(verDir, func(path string, d os.DirEntry, err error) error {
+		if err == nil && !d.IsDir() && filepath.Base(path) == binaryName {
+			found = path
+			return fmt.Errorf("stop")
+		}
+		return nil
+	})
+	if found == "" {
+		return "", fmt.Errorf("binary %s not found in %s", binaryName, verDir)
+	}
+	return found, nil
+}

--- a/internal/installer/extract.go
+++ b/internal/installer/extract.go
@@ -1,0 +1,114 @@
+package installer
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func isArchive(name string) bool {
+	return strings.HasSuffix(name, ".tar.gz") || strings.HasSuffix(name, ".tgz") || strings.HasSuffix(name, ".zip")
+}
+
+func extractTo(src, dst string) error {
+	switch {
+	case strings.HasSuffix(src, ".tar.gz") || strings.HasSuffix(src, ".tgz"):
+		return untarGZ(src, dst)
+	case strings.HasSuffix(src, ".zip"):
+		return unzip(src, dst)
+	default:
+		return fmt.Errorf("not an archive: %s", src)
+	}
+}
+
+func untarGZ(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	f, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	gzr, err := gzip.NewReader(f)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+	tr := tar.NewReader(gzr)
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, h.Name)
+		switch h.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(h.Mode)); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(h.Mode))
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, tr); err != nil {
+				out.Close()
+				return err
+			}
+			out.Close()
+		}
+	}
+	return nil
+}
+
+func unzip(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	r, err := zip.OpenReader(src)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	for _, f := range r.File {
+		target := filepath.Join(dst, f.Name)
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
+		if err != nil {
+			rc.Close()
+			return err
+		}
+		if _, err := io.Copy(out, rc); err != nil {
+			rc.Close()
+			out.Close()
+			return err
+		}
+		rc.Close()
+		out.Close()
+	}
+	return nil
+}

--- a/internal/installer/fs.go
+++ b/internal/installer/fs.go
@@ -1,0 +1,44 @@
+package installer
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func copyFileMode(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func atomicSymlink(target, link string) error {
+	tmp := link + ".new"
+	_ = os.Remove(tmp)
+	if err := os.Symlink(target, tmp); err != nil {
+		return err
+	}
+	_ = os.Remove(link)
+	return os.Rename(tmp, link)
+}
+
+func ensureSymlink(link, target string) error {
+	if err := os.Remove(link); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return os.Symlink(target, link)
+}

--- a/internal/installer/github.go
+++ b/internal/installer/github.go
@@ -1,0 +1,49 @@
+package installer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type ghRelease struct {
+	TagName    string `json:"tag_name"`
+	Prerelease bool   `json:"prerelease"`
+	Draft      bool   `json:"draft"`
+}
+
+func resolveLatestTag(ctx context.Context, cli *http.Client, owner, repo, channel, token string) (string, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases?per_page=30", owner, repo)
+	resp, err := httpGET(ctx, cli, url, token)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("GitHub API %s: %s", url, resp.Status)
+	}
+	var rels []ghRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rels); err != nil {
+		return "", err
+	}
+	if strings.ToLower(channel) == "canary" {
+		for _, r := range rels {
+			if !r.Draft && r.Prerelease {
+				return r.TagName, nil
+			}
+		}
+	}
+	for _, r := range rels {
+		if !r.Draft && !r.Prerelease {
+			return r.TagName, nil
+		}
+	}
+	for _, r := range rels {
+		if !r.Draft {
+			return r.TagName, nil
+		}
+	}
+	return "", fmt.Errorf("no releases found for %s/%s", owner, repo)
+}

--- a/internal/installer/http.go
+++ b/internal/installer/http.go
@@ -1,0 +1,56 @@
+package installer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"time"
+)
+
+// DefaultHTTPTimeout defines default timeout for network requests.
+const DefaultHTTPTimeout = 20 * time.Second
+
+func newHTTPClient(timeout time.Duration) *http.Client {
+	if timeout <= 0 {
+		timeout = DefaultHTTPTimeout
+	}
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           (&net.Dialer{Timeout: 10 * time.Second}).DialContext,
+			IdleConnTimeout:       30 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+}
+
+func httpGET(ctx context.Context, cli *http.Client, url string, token string) (*http.Response, error) {
+	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return cli.Do(req)
+}
+
+func downloadToFile(ctx context.Context, cli *http.Client, url, token, dst string) error {
+	resp, err := httpGET(ctx, cli, url, token)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	f, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, resp.Body)
+	return err
+}

--- a/internal/installer/install.go
+++ b/internal/installer/install.go
@@ -1,0 +1,124 @@
+package installer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Install installs or updates a tool.
+func Install(ctx context.Context, cfg Config, tool string, explicitTag string) error {
+	m, err := LoadManifest(cfg.ToolsDir, tool)
+	if err != nil {
+		return err
+	}
+	cli := newHTTPClient(cfg.HTTPTimeout)
+	tag := explicitTag
+	if tag == "" {
+		tag, err = resolveLatestTag(ctx, cli, m.Owner, m.Repo, cfg.Channel, cfg.GHToken)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("[cdactl] %s: tag=%s channel=%s\n", m.Name, tag, cfg.Channel)
+	verDir := filepath.Join(m.Prefix, tag)
+	curLink := filepath.Join(m.Prefix, "current")
+	if _, err := os.Stat(verDir); err == nil && !cfg.Force {
+		fmt.Printf("[cdactl] %s: version already present at %s\n", m.Name, verDir)
+	} else {
+		if err := os.MkdirAll(verDir, 0o755); err != nil {
+			return err
+		}
+		osVal, archVal := osID(), archID()
+		asset := m.AssetTemplate
+		asset = strings.ReplaceAll(asset, "{os}", osVal)
+		asset = strings.ReplaceAll(asset, "{arch}", archVal)
+		asset = strings.ReplaceAll(asset, "{tag}", tag)
+		url := ""
+		if m.Mirror != "" {
+			url = m.Mirror
+			url = strings.ReplaceAll(url, "{tag}", tag)
+			url = strings.ReplaceAll(url, "{asset}", asset)
+		} else {
+			url = fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s", m.Owner, m.Repo, tag, asset)
+		}
+		tmp := filepath.Join(os.TempDir(), m.Name+"-"+tag+".dl")
+		fmt.Println("[cdactl] fetching:", url)
+		if err := downloadToFile(ctx, cli, url, cfg.GHToken, tmp); err != nil {
+			return err
+		}
+		csURL := url + ".sha256"
+		csTmp := tmp + ".sha256"
+		if err := downloadToFile(ctx, cli, csURL, cfg.GHToken, csTmp); err == nil {
+			if b, err := os.ReadFile(csTmp); err == nil {
+				if err := verifySha256(tmp, string(b)); err != nil {
+					return err
+				}
+				fmt.Println("[cdactl] checksum OK")
+			}
+			_ = os.Remove(csTmp)
+		}
+		dstBin := filepath.Join(verDir, m.BinaryName)
+		if isArchive(asset) {
+			if err := extractTo(tmp, verDir); err != nil {
+				return err
+			}
+			found, err := guessInstalledBinary(verDir, m.BinaryName)
+			if err != nil {
+				return err
+			}
+			if err := os.Chmod(found, 0o755); err != nil {
+				return err
+			}
+			if found != dstBin {
+				if err := os.Rename(found, dstBin); err != nil {
+					return err
+				}
+			}
+		} else {
+			if err := copyFileMode(tmp, dstBin, 0o755); err != nil {
+				return err
+			}
+		}
+		_ = os.Remove(tmp)
+		fmt.Println("[cdactl] installed into", verDir)
+	}
+	if err := atomicSymlink(verDir, curLink); err != nil {
+		return err
+	}
+	fmt.Printf("[cdactl] current -> %s\n", verDir)
+	link := filepath.Join(cfg.BinDirLink, m.Name)
+	target := filepath.Join(curLink, m.BinaryName)
+	if err := ensureSymlink(link, target); err != nil {
+		fmt.Printf("[cdactl] WARN: linking %s -> %s failed: %v\n", link, target, err)
+		fmt.Println("         Try: sudo ln -sfn", target, link)
+		return nil
+	}
+	fmt.Printf("[cdactl] linked %s -> %s\n", link, target)
+	return nil
+}
+
+func osID() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "darwin"
+	case "linux":
+		return "linux"
+	default:
+		return runtime.GOOS
+	}
+}
+
+func archID() string {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "amd64"
+	case "arm64":
+		return "arm64"
+	default:
+		return runtime.GOARCH
+	}
+}

--- a/internal/installer/manifest.go
+++ b/internal/installer/manifest.go
@@ -1,0 +1,55 @@
+package installer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadManifest loads a manifest file by tool name.
+func LoadManifest(dir, tool string) (*Manifest, error) {
+	path := filepath.Join(dir, tool+".yaml")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest %s: %w", path, err)
+	}
+	var m Manifest
+	if err := yaml.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("parse manifest %s: %w", path, err)
+	}
+	if m.Name == "" {
+		m.Name = tool
+	}
+	if m.Prefix == "" {
+		m.Prefix = filepath.Join("/opt/cdaprod", m.Name)
+	}
+	if m.BinaryName == "" {
+		m.BinaryName = m.Name
+	}
+	return &m, nil
+}
+
+// LoadAllManifests returns all manifests within dir.
+func LoadAllManifests(dir string) ([]*Manifest, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []*Manifest
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
+			continue
+		}
+		m, err := LoadManifest(dir, e.Name()[:len(e.Name())-5])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}

--- a/internal/installer/manifest_test.go
+++ b/internal/installer/manifest_test.go
@@ -1,0 +1,26 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadManifest(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("name: demo\nowner: foo\nrepo: bar\nasset_template: bin_{os}_{arch}\nbinary_name: demo\n")
+	if err := os.WriteFile(filepath.Join(dir, "demo.yaml"), data, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	m, err := LoadManifest(dir, "demo")
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if m.Name != "demo" || m.Owner != "foo" || m.Repo != "bar" {
+		t.Fatalf("unexpected manifest: %+v", m)
+	}
+	list, err := LoadAllManifests(dir)
+	if err != nil || len(list) != 1 {
+		t.Fatalf("LoadAllManifests: %v len=%d", err, len(list))
+	}
+}

--- a/internal/installer/types.go
+++ b/internal/installer/types.go
@@ -1,0 +1,26 @@
+package installer
+
+import "time"
+
+// Config describes installer behaviour.
+// Provided by CLI layer.
+type Config struct {
+	ToolsDir    string        // directory with manifests
+	PrefixBase  string        // base directory for installs
+	BinDirLink  string        // directory for symlinks (/usr/local/bin)
+	Channel     string        // release channel
+	Force       bool          // reinstall if exists
+	GHToken     string        // optional GitHub token
+	HTTPTimeout time.Duration // network timeout
+}
+
+// Manifest describes a tool release.
+type Manifest struct {
+	Name          string `yaml:"name"`
+	Owner         string `yaml:"owner"`
+	Repo          string `yaml:"repo"`
+	AssetTemplate string `yaml:"asset_template"`
+	BinaryName    string `yaml:"binary_name"`
+	Prefix        string `yaml:"prefix"`
+	Mirror        string `yaml:"mirror"`
+}

--- a/list.go
+++ b/list.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/Cdaprod/cdactl/internal/installer"
+	"github.com/spf13/cobra"
+)
+
+// cdactl list
+// Example:
+//
+//	cdactl list
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available tool manifests",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ms, err := installer.LoadAllManifests(defaultToolsDir())
+		if err != nil {
+			return err
+		}
+		if len(ms) == 0 {
+			fmt.Println("no manifests found")
+			return nil
+		}
+		fmt.Println("Available tools:")
+		for _, m := range ms {
+			fmt.Printf("  %s (%s/%s) asset:%s prefix:%s\n", m.Name, m.Owner, m.Repo, m.AssetTemplate, filepath.Clean(m.Prefix))
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "cdactl",
+	Short: "cdactl manages system tools and utilities",
+	Long:  "cdactl is a small CLI for installing and updating helper tools.",
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/main_util_paths.go
+++ b/main_util_paths.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// defaultToolsDir returns location of tool manifests.
+// Usage:
+//
+//	dir := defaultToolsDir()
+func defaultToolsDir() string {
+	if v := os.Getenv("CDACTL_TOOLS_DIR"); v != "" {
+		return v
+	}
+	if wd, err := os.Getwd(); err == nil {
+		if st, err := os.Stat(filepath.Join(wd, "tools.d")); err == nil && st.IsDir() {
+			return filepath.Join(wd, "tools.d")
+		}
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config", "cdactl", "tools.d")
+}

--- a/remove.go
+++ b/remove.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// cdactl remove <tool>
+// Example:
+//
+//	cdactl remove codex-switch --all
+var (
+	removeAll bool
+)
+
+var removeCmd = &cobra.Command{
+	Use:   "remove <tool>",
+	Short: "Remove installed versions for a tool",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		prefix := filepath.Join("/opt/cdaprod", args[0])
+		if _, err := os.Stat(prefix); err != nil {
+			return fmt.Errorf("no install tree at %s", prefix)
+		}
+		if removeAll {
+			return os.RemoveAll(prefix)
+		}
+		entries, err := os.ReadDir(prefix)
+		if err != nil {
+			return err
+		}
+		fmt.Println("existing versions in", prefix)
+		for _, e := range entries {
+			if e.IsDir() {
+				fmt.Println("  ", e.Name())
+			}
+		}
+		fmt.Println("use --all to remove all versions")
+		return nil
+	},
+}
+
+func init() {
+	removeCmd.Flags().BoolVar(&removeAll, "all", false, "delete all versions")
+	rootCmd.AddCommand(removeCmd)
+}

--- a/tools.d/codex-switch.yaml
+++ b/tools.d/codex-switch.yaml
@@ -1,0 +1,7 @@
+name: codex-switch
+owner: Cdaprod
+repo: ThatDAMToolbox
+asset_template: codex-switch_{os}_{arch}
+binary_name: codex-switch
+prefix: /opt/cdaprod/codex-switch
+mirror: ""

--- a/tools.d/thatdamtoolbox.yaml
+++ b/tools.d/thatdamtoolbox.yaml
@@ -1,0 +1,7 @@
+name: thatdamtoolbox
+owner: Cdaprod
+repo: ThatDAMToolbox
+asset_template: thatdamtoolbox_{os}_{arch}
+binary_name: thatdamtoolbox
+prefix: /opt/cdaprod/thatdamtoolbox
+mirror: ""

--- a/unlink.go
+++ b/unlink.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// cdactl unlink <tool>
+// Example:
+//
+//	cdactl unlink codex-switch
+var unlinkCmd = &cobra.Command{
+	Use:   "unlink <tool>",
+	Short: "Remove /usr/local/bin symlink for tool",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		link := filepath.Join("/usr/local/bin", args[0])
+		if err := os.Remove(link); err != nil {
+			return fmt.Errorf("remove %s: %w", link, err)
+		}
+		fmt.Println("removed", link)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(unlinkCmd)
+}

--- a/update.go
+++ b/update.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/Cdaprod/cdactl/internal/installer"
+	"github.com/spf13/cobra"
+)
+
+// cdactl update <tool>
+// Example:
+//
+//	cdactl update codex-switch --channel canary
+var updateCmd = &cobra.Command{
+	Use:   "update <tool>",
+	Short: "Update a tool to latest or specific version",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tool := args[0]
+		cfg := installer.Config{
+			ToolsDir:    defaultToolsDir(),
+			PrefixBase:  "/opt/cdaprod",
+			BinDirLink:  "/usr/local/bin",
+			Channel:     channel,
+			Force:       force,
+			GHToken:     os.Getenv("GITHUB_TOKEN"),
+			HTTPTimeout: installer.DefaultHTTPTimeout,
+		}
+		return installer.Install(context.Background(), cfg, tool, version)
+	},
+}
+
+func init() {
+	updateCmd.Flags().StringVar(&version, "version", "", "explicit release tag")
+	updateCmd.Flags().StringVar(&channel, "channel", "stable", "release channel")
+	updateCmd.Flags().BoolVar(&force, "force", false, "reinstall even if present")
+	rootCmd.AddCommand(updateCmd)
+}

--- a/which.go
+++ b/which.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// cdactl which <tool>
+// Example:
+//
+//	cdactl which codex-switch
+var whichCmd = &cobra.Command{
+	Use:   "which <tool>",
+	Short: "Show symlink target for a tool",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		link := filepath.Join("/usr/local/bin", args[0])
+		target, err := os.Readlink(link)
+		if err != nil {
+			return fmt.Errorf("%s: %w", link, err)
+		}
+		fmt.Printf("%s -> %s\n", link, target)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(whichCmd)
+}


### PR DESCRIPTION
## Summary
- add installer commands for fetching GitHub release binaries
- support manifests and atomic symlink updates under /opt/cdaprod
- document tool installation feature in README

## Testing
- `go test ./...`

## Checklist
- [x] Code is self-contained and idempotent.
- [x] No unnecessary new files or external dependencies.
- [x] Tests added or updated as appropriate.
- [x] Docs updated where needed.


------
https://chatgpt.com/codex/tasks/task_e_68bdbb56d1d083269095f01147557ca2